### PR TITLE
Change add to cart button color to red (fix #1)

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -76,7 +76,7 @@ export default {
 .add-to-cart-btn {
   width: 100%;
   padding: 12px;
-  background: #007bff;
+  background: #c82333;
   color: white;
   border: none;
   border-radius: 5px;
@@ -85,6 +85,6 @@ export default {
 }
 
 .add-to-cart-btn:hover {
-  background: #0056b3;
+  background: #a71e2a;
 }
 </style>


### PR DESCRIPTION
## Summary
- Changed add to cart button color from blue (#007bff) to dark red (#c82333)
- Applied appropriate hover state with darker red (#a71e2a)
- Maintains accessibility and visual hierarchy

## Related Issue
- Closes #1

## Testing
- [x] Button color changed to dark red suitable for CTA
- [x] Button functionality unchanged
- [x] No visual conflicts with other elements
- [x] Development server tested on localhost:3001

🤖 Generated with [Claude Code](https://claude.ai/code)