### PR TITLE
Change checkout button color to red (fix #4)

### DIFF
--- a/src/views/Cart.vue
+++ b/src/views/Cart.vue
@@ -144,7 +144,7 @@ export default {
 }
 
 .checkout-btn {
-  background: #28a745;
+  background: #dc3545;
   color: white;
   border: none;
   padding: 12px 24px;


### PR DESCRIPTION
## Summary
- Changed checkout button color from green (#28a745) to red (#dc3545)
- Updated CSS styling in Cart.vue component

## Changes Made
- Modified  background color in src/views/Cart.vue:147

## Test Plan
- [x] Verify button appears red in browser
- [x] Confirm button functionality remains unchanged
- [x] Ensure consistent styling with other red buttons in the app

## Related Issue
- Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>