### PR TITLE
Change navigation buttons to red color (fix #3)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -61,7 +61,7 @@ header {
 nav button {
   margin-left: 10px;
   padding: 10px 20px;
-  background: #007bff;
+  background: #dc3545;
   color: white;
   border: none;
   border-radius: 5px;
@@ -69,6 +69,6 @@ nav button {
 }
 
 nav button:hover {
-  background: #0056b3;
+  background: #c82333;
 }
 </style>


### PR DESCRIPTION
## Summary
- Changed navigation button colors from blue to red
- Updated both Products and Cart button styling
- Both normal and hover states now use red color scheme

## Changes Made
- Updated button background color from `#007bff` to `#dc3545` (red)
- Updated button hover color from `#0056b3` to `#c82333` (darker red)

## Acceptance Criteria Met
- [x] Products button changed to red
- [x] Cart button changed to red

## Test plan
- [x] Verified navigation buttons display in red color
- [x] Verified hover states work correctly
- [x] Tested locally on development server

Closes #3